### PR TITLE
To escape dot at the beginning of line

### DIFF
--- a/imgp.1
+++ b/imgp.1
@@ -151,11 +151,11 @@ Set hres=800 and adapt vres maintaining the ratio.
 .B $ imgp -x 800x0
 Source omitted. Processing current directory...
 
-./image1.jpg
+\[char46]/image1.jpg
 1366x911 -> 800x534
 69022 bytes -> 35123 bytes
 
-./image2.jpg
+\[char46]/image2.jpg
 1050x1400 -> 800x1067
 458092 bytes -> 78089 bytes
 .SH AUTHORS


### PR DESCRIPTION
The dot should be escaped or get following error
    <standard input>:154: warning: macro `/image1.jpg' not defined
    <standard input>:158: warning: macro `/image2.jpg' not defined

Please refer to following test command.
    man --warnings -E UTF-8 -l -Tutf8 -Z ./imgp.1 >/dev/null