### PR TITLE
Fix options in man page

### DIFF
--- a/imgp.1
+++ b/imgp.1
@@ -97,10 +97,10 @@ Save the image with a specified quality factor N (scale 1-95, default 75). JPEG 
 .BI "-m, --mute"
 Do not show any operational output.
 .TP
-.BI "-r, --recursive"
+.BI "-r, --recurse"
 Recursively process sub-directories. By default only the specified directory is processed. Symbolic links are ignored to avoid recursive loops.
 .TP
-.BI "-s, --recursive=" byte
+.BI "-s, --size=" byte
 Minimum size in bytes required to process an image. Acts as a guard against processing low-resolution images. Default 1024 bytes.
 .TP
 .BI "-w, --overwrite"


### PR DESCRIPTION
Fix the `--recurse` and `--size` arguments in the man page.