### PR TITLE
Support converting P mode PNGs

### DIFF
--- a/imgp
+++ b/imgp
@@ -190,6 +190,8 @@ def rotate_image(src):
             background = Image.new(img.mode[:-1], img.size, fill_color)
             background.paste(img, img.split()[-1])
             img = background
+        elif img.mode == "P":
+            img.convert("RGBA")
         dest = name + suffix + '.jpg'
         _format = 'JPEG'
         converted = True
@@ -434,6 +436,8 @@ def resize_image(src):
             background = Image.new(img.mode[:-1], img.size, fill_color)
             background.paste(img, img.split()[-1])
             img = background
+        elif img.mode == "P":
+            img = img.convert("RGBA")
         dest = name + suffix + '.jpg'
         _format = 'JPEG'
         converted = True

--- a/imgp
+++ b/imgp
@@ -147,11 +147,6 @@ def rotate_image(src):
                 lock_print(src + ': not JPEG/PNG/MPO. format: ' + _format)
             return
 
-        if convert and _format == 'PNG' and img.mode == 'P':
-            if debug:
-                lock_print('rotate_image: cannot convert PNG files in palette mode')
-            return
-
         try:
             if _format == 'JPEG' and not _progressive and img.info['progressive']:
                 if debug:
@@ -231,11 +226,6 @@ def resize_image(src):
         if _format not in ['JPEG', 'PNG', 'MPO']:
             if debug:
                 lock_print(src + ': not JPEG/PNG/MPO. format: ' + _format)
-            return
-
-        if convert and _format == 'PNG' and img.mode == 'P':
-            if debug:
-                lock_print('resize_image: cannot convert PNG files in palette mode')
             return
 
         # check if convert or progressive is specified without any resolution option


### PR DESCRIPTION
Figured out the limitation in PIL: P mode PNGs cannot be converted to JPEG. When first converting to RGB(A) mode, it works, though.

[Stackoverflow](https://stackoverflow.com/a/59476938/8676616) has the answer, as always. :-)

Adds conditional conversion to RGBA mode and removes guards introduced in #30.

Tested locally with this screenshot:
![stackoverflow_screenshot_img_mode_convert](https://user-images.githubusercontent.com/1798823/192084820-a582fab6-079d-41ac-9e18-0b8fafe706ef.png)

```
python imgp --convert --overwrite screenshot.png
# and
python imgp --convert --overwrite --rotate 90 screenshot.png
```

Fixes #50