### PR TITLE
chore: update to use SPDX license (`GPL-3.0-or-later`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://repology.org/project/imgp/versions"><img src="https://repology.org/badge/tiny-repos/imgp.svg" alt="Availability"></a>
 <a href="https://pypi.org/project/imgp/"><img src="https://img.shields.io/pypi/v/imgp.svg?maxAge=600" alt="PyPI" /></a>
 <a href="https://circleci.com/gh/jarun/workflows/imgp"><img src="https://img.shields.io/circleci/project/github/jarun/imgp.svg" alt="Build Status" /></a>
-<a href="https://github.com/jarun/imgp/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-yellowgreen.svg?maxAge=2592000" alt="License" /></a>
+<a href="https://github.com/jarun/imgp/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3+-yellowgreen.svg?maxAge=2592000" alt="License" /></a>
 </p>
 
 <p align="center">

--- a/imgp
+++ b/imgp
@@ -461,7 +461,7 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
         file.write('''
 Version %s
 Copyright © 2016-2023 Arun Prakash Jana <engineerarun@gmail.com>
-License: GPLv3
+License: GPL-3.0-or-later
 Webpage: https://github.com/jarun/imgp
 ''' % _VERSION_)
 

--- a/imgp.1
+++ b/imgp.1
@@ -216,6 +216,6 @@ Arun Prakash Jana <engineerarun@gmail.com>
 .SH LICENSE
 Copyright \(co 2016-2023 Arun Prakash Jana <engineerarun@gmail.com>
 .PP
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
+License GPL-3.0-or-later+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
 .br
 This is free software: you are free to change and redistribute it. There is NO WARRANTY, to the extent permitted by law.

--- a/packagecore.yaml
+++ b/packagecore.yaml
@@ -1,6 +1,6 @@
 name: imgp
 maintainer: Arun Prakash Jana <engineerarun@gmail.com>
-license: GPLv3
+license: GPL-3.0-or-later
 summary: High-performance cli batch image resizer and rotator.
 homepage: https://github.com/jarun/imgp
 commands:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author='Arun Prakash Jana',
     author_email='engineerarun@gmail.com',
     url='https://github.com/jarun/imgp',
-    license='GPLv3',
+    license='GPL-3.0-or-later',
     license_file='LICENSE',
     python_requires='>=3.8',  # requires pip>=9.0.0
     platforms=['any'],
@@ -53,7 +53,7 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: End Users/Desktop',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPL-3.0-or-later)',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Update to use SPDX license identifier, https://spdx.org/licenses/GPL-3.0-or-later